### PR TITLE
Remove the ADStatus setting from writeInt32().

### DIFF
--- a/rixscamApp/src/rixscam.cpp
+++ b/rixscamApp/src/rixscam.cpp
@@ -1302,18 +1302,6 @@ asynStatus xcamCamera::writeInt32(asynUser *pasynUser, epicsInt32 value)
 			}
 			setStringParam(ADStatusMessage, "Acquiring data");
 		}
-		if (!value && acquiring)
-		{
-			setStringParam(ADStatusMessage, "Acquisition stopped");
-			if (imageMode == ADImageContinuous)
-			{
-				setIntegerParam(ADStatus, ADStatusIdle);
-			}
-			else
-			{
-				setIntegerParam(ADStatus, ADStatusAborted);
-			}
-		}
 	}
 	else if (_paramCCD_POWER.HasParameterIndex(function))
 	{


### PR DESCRIPTION
This is already being done in the imageTask, since it is who is really able to determine when we have effectively aborted, and make it possible for higher layer applications to rely on these states.